### PR TITLE
use a formatter instead of building intermediate strings

### DIFF
--- a/lib/expression.ml
+++ b/lib/expression.ml
@@ -181,15 +181,15 @@ let rec type_of (e : expr) : expr_type =
 let negate_relop (e : expr) : expr =
   match e with
   | Relop (op, e1, e2) -> (
-      match op with
-      | Int op' -> Relop (Int (I.neg_relop op'), e1, e2)
-      | Real op' -> Relop (Real (R.neg_relop op'), e1, e2)
-      | Bool op' -> Relop (Bool (B.neg_relop op'), e1, e2)
-      | Str op' -> Relop (Str (S.neg_relop op'), e1, e2)
-      | I32 op' -> Relop (I32 (I32.neg_relop op'), e1, e2)
-      | I64 op' -> Relop (I64 (I64.neg_relop op'), e1, e2)
-      | F32 op' -> Relop (F32 (F32.neg_relop op'), e1, e2)
-      | F64 op' -> Relop (F64 (F64.neg_relop op'), e1, e2) )
+    match op with
+    | Int op' -> Relop (Int (I.neg_relop op'), e1, e2)
+    | Real op' -> Relop (Real (R.neg_relop op'), e1, e2)
+    | Bool op' -> Relop (Bool (B.neg_relop op'), e1, e2)
+    | Str op' -> Relop (Str (S.neg_relop op'), e1, e2)
+    | I32 op' -> Relop (I32 (I32.neg_relop op'), e1, e2)
+    | I64 op' -> Relop (I64 (I64.neg_relop op'), e1, e2)
+    | F32 op' -> Relop (F32 (F32.neg_relop op'), e1, e2)
+    | F64 op' -> Relop (F64 (F64.neg_relop op'), e1, e2) )
   | _ -> raise InvalidRelop
 
 let pp_unop fmt =
@@ -259,25 +259,19 @@ let pp_quantifier fmt = function
 let pp_vars fmt vars =
   Format.pp_print_list
     ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ", ")
-    Symbol.pp
-    fmt vars
+    Symbol.pp fmt vars
 
 let rec pp fmt (e : expr) =
   let fprintf = Format.fprintf in
   match e with
   | Val v -> fprintf fmt "%a" Value.pp v
-  | SymPtr (base, offset) ->
-    fprintf fmt "(i32.add (i32 %ld) %a)" base pp offset
-  | Unop (op, e) ->
-    fprintf fmt "(%a %a)" pp_unop op pp e
-  | Binop (op, e1, e2) ->
-    fprintf fmt "(%a %a %a)" pp_binop op pp e1 pp e2
+  | SymPtr (base, offset) -> fprintf fmt "(i32.add (i32 %ld) %a)" base pp offset
+  | Unop (op, e) -> fprintf fmt "(%a %a)" pp_unop op pp e
+  | Binop (op, e1, e2) -> fprintf fmt "(%a %a %a)" pp_binop op pp e1 pp e2
   | Triop (op, e1, e2, e3) ->
     fprintf fmt "(%a %a %a %a)" pp_triop op pp e1 pp e2 pp e3
-  | Relop (op, e1, e2) ->
-    fprintf fmt "(%a %a %a)" pp_relop op pp e1 pp e2
-  | Cvtop (op, e) ->
-    fprintf fmt "(%a %a)" pp_cvtop op pp e
+  | Relop (op, e1, e2) -> fprintf fmt "(%a %a %a)" pp_relop op pp e1 pp e2
+  | Cvtop (op, e) -> fprintf fmt "(%a %a)" pp_cvtop op pp e
   | Symbol s -> fprintf fmt "%a" Symbol.pp s
   | Extract (e, h, l) -> fprintf fmt "(extract %a %d %d)" pp e l h
   | Concat (e1, e2) -> fprintf fmt "(++ %a %a)" pp e1 pp e2
@@ -368,176 +362,176 @@ let rec simplify ?(extract = true) (e : expr) : expr =
   | Val v -> Val v
   | SymPtr (base, offset) -> SymPtr (base, simplify offset)
   | Binop (I32 op, e1, e2) -> (
-      let e1' = simplify e1
-      and e2' = simplify e2 in
-      match (e1', e2') with
-      | SymPtr (b1, os1), SymPtr (b2, os2) -> (
-          match op with
-          | Sub when Int32.(b1 = b2) -> simplify (Binop (I32 Sub, os1, os2))
-          | _ -> Binop (I32 op, e1', e2') )
-      | SymPtr (base, offset), _ -> (
-          match op with
-          | Add ->
-            let new_offset = simplify (Binop (I32 Add, offset, e2')) in
-            simplify (SymPtr (base, new_offset))
-          | Sub ->
-            let new_offset = simplify (Binop (I32 Sub, offset, e2')) in
-            simplify (SymPtr (base, new_offset))
-          | _ -> Binop (I32 op, e1', e2') )
-      | _, SymPtr (base, offset) -> (
-          match op with
-          | Add ->
-            let new_offset = simplify (Binop (I32 Add, offset, e1')) in
-            simplify (SymPtr (base, new_offset))
-          | _ -> Binop (I32 op, e1', e2') )
-      | Val (Num (I32 0l)), _ -> (
-          match op with
-          | Add | Or | Sub -> e2'
-          | And | DivS | DivU | Mul | RemS | RemU -> Val (Num (I32 0l))
-          | _ -> Binop (I32 op, e1', e2') )
-      | _, Val (Num (I32 0l)) -> (
-          match op with
-          | Add | Or | Sub -> e1'
-          | And | Mul -> Val (Num (I32 0l))
-          | _ -> Binop (I32 op, e1', e2') )
-      | Val (Num n1), Val (Num n2) ->
-        Val (Num (Eval_numeric.eval_binop (I32 op) n1 n2))
-      | Binop (I32 op2, x, Val (Num v1)), Val (Num v2) when not (is_num x) -> (
-          match (op, op2) with
-          | Add, Add ->
-            let v = Eval_numeric.eval_binop (I32 Add) v1 v2 in
-            Binop (I32 Add, x, Val (Num v))
-          | Add, Sub | Sub, Add ->
-            let v = Eval_numeric.eval_binop (I32 Sub) v1 v2 in
-            Binop (I32 Add, x, Val (Num v))
-          | Sub, Sub ->
-            let v = Eval_numeric.eval_binop (I32 Add) v1 v2 in
-            Binop (I32 Sub, x, Val (Num v))
-          | _, _ -> Binop (I32 op, e1', e2') )
-      | (bop, Val (Num (I32 1l)) | Val (Num (I32 1l)), bop)
-        when is_relop bop && Poly.(op = And) ->
-        bop
+    let e1' = simplify e1
+    and e2' = simplify e2 in
+    match (e1', e2') with
+    | SymPtr (b1, os1), SymPtr (b2, os2) -> (
+      match op with
+      | Sub when Int32.(b1 = b2) -> simplify (Binop (I32 Sub, os1, os2))
       | _ -> Binop (I32 op, e1', e2') )
+    | SymPtr (base, offset), _ -> (
+      match op with
+      | Add ->
+        let new_offset = simplify (Binop (I32 Add, offset, e2')) in
+        simplify (SymPtr (base, new_offset))
+      | Sub ->
+        let new_offset = simplify (Binop (I32 Sub, offset, e2')) in
+        simplify (SymPtr (base, new_offset))
+      | _ -> Binop (I32 op, e1', e2') )
+    | _, SymPtr (base, offset) -> (
+      match op with
+      | Add ->
+        let new_offset = simplify (Binop (I32 Add, offset, e1')) in
+        simplify (SymPtr (base, new_offset))
+      | _ -> Binop (I32 op, e1', e2') )
+    | Val (Num (I32 0l)), _ -> (
+      match op with
+      | Add | Or | Sub -> e2'
+      | And | DivS | DivU | Mul | RemS | RemU -> Val (Num (I32 0l))
+      | _ -> Binop (I32 op, e1', e2') )
+    | _, Val (Num (I32 0l)) -> (
+      match op with
+      | Add | Or | Sub -> e1'
+      | And | Mul -> Val (Num (I32 0l))
+      | _ -> Binop (I32 op, e1', e2') )
+    | Val (Num n1), Val (Num n2) ->
+      Val (Num (Eval_numeric.eval_binop (I32 op) n1 n2))
+    | Binop (I32 op2, x, Val (Num v1)), Val (Num v2) when not (is_num x) -> (
+      match (op, op2) with
+      | Add, Add ->
+        let v = Eval_numeric.eval_binop (I32 Add) v1 v2 in
+        Binop (I32 Add, x, Val (Num v))
+      | Add, Sub | Sub, Add ->
+        let v = Eval_numeric.eval_binop (I32 Sub) v1 v2 in
+        Binop (I32 Add, x, Val (Num v))
+      | Sub, Sub ->
+        let v = Eval_numeric.eval_binop (I32 Add) v1 v2 in
+        Binop (I32 Sub, x, Val (Num v))
+      | _, _ -> Binop (I32 op, e1', e2') )
+    | (bop, Val (Num (I32 1l)) | Val (Num (I32 1l)), bop)
+      when is_relop bop && Poly.(op = And) ->
+      bop
+    | _ -> Binop (I32 op, e1', e2') )
   | Binop (I64 op, e1, e2) -> (
-      let e1' = simplify e1
-      and e2' = simplify e2 in
-      match (e1', e2') with
-      | SymPtr (b1, os1), SymPtr (b2, os2) -> (
-          match op with
-          | Sub when Int32.(b1 = b2) -> simplify (Binop (I64 Sub, os1, os2))
-          | _ -> Binop (I64 op, e1', e2') )
-      | SymPtr (base, offset), _ -> (
-          match op with
-          | Add ->
-            let new_offset = simplify (Binop (I64 Add, offset, e2')) in
-            simplify (SymPtr (base, new_offset))
-          | Sub ->
-            let new_offset = simplify (Binop (I64 Sub, offset, e2')) in
-            simplify (SymPtr (base, new_offset))
-          | _ -> Binop (I64 op, e1', e2') )
-      | _, SymPtr (base, offset) -> (
-          match op with
-          | Add ->
-            let new_offset = simplify (Binop (I64 Add, offset, e1')) in
-            simplify (SymPtr (base, new_offset))
-          | _ -> Binop (I64 op, e1', e2') )
-      | Val (Num (I64 0L)), _ -> (
-          match op with
-          | Add | Or | Sub -> e2'
-          | And | DivS | DivU | Mul | RemS | RemU -> Val (Num (I64 0L))
-          | _ -> Binop (I64 op, e1', e2') )
-      | _, Val (Num (I64 0L)) -> (
-          match op with
-          | Add | Or | Sub -> e1'
-          | And | Mul -> Val (Num (I64 0L))
-          | _ -> Binop (I64 op, e1', e2') )
-      | Val (Num v1), Val (Num v2) ->
-        Val (Num (Eval_numeric.eval_binop (I64 op) v1 v2))
-      | Binop (I64 op2, x, Val (Num v1)), Val (Num v2) when not (is_num x) -> (
-          match (op, op2) with
-          | Add, Add ->
-            let v = Eval_numeric.eval_binop (I64 Add) v1 v2 in
-            Binop (I64 Add, x, Val (Num v))
-          | Add, Sub | Sub, Add ->
-            let v = Eval_numeric.eval_binop (I64 Sub) v1 v2 in
-            Binop (I64 Add, x, Val (Num v))
-          | Sub, Sub ->
-            let v = Eval_numeric.eval_binop (I64 Add) v1 v2 in
-            Binop (I64 Sub, x, Val (Num v))
-          | _, _ -> Binop (I64 op, e1', e2') )
-      | (bop, Val (Num (I64 1L)) | Val (Num (I64 1L)), bop)
-        when is_relop bop && Poly.(op = And) ->
-        bop
+    let e1' = simplify e1
+    and e2' = simplify e2 in
+    match (e1', e2') with
+    | SymPtr (b1, os1), SymPtr (b2, os2) -> (
+      match op with
+      | Sub when Int32.(b1 = b2) -> simplify (Binop (I64 Sub, os1, os2))
       | _ -> Binop (I64 op, e1', e2') )
+    | SymPtr (base, offset), _ -> (
+      match op with
+      | Add ->
+        let new_offset = simplify (Binop (I64 Add, offset, e2')) in
+        simplify (SymPtr (base, new_offset))
+      | Sub ->
+        let new_offset = simplify (Binop (I64 Sub, offset, e2')) in
+        simplify (SymPtr (base, new_offset))
+      | _ -> Binop (I64 op, e1', e2') )
+    | _, SymPtr (base, offset) -> (
+      match op with
+      | Add ->
+        let new_offset = simplify (Binop (I64 Add, offset, e1')) in
+        simplify (SymPtr (base, new_offset))
+      | _ -> Binop (I64 op, e1', e2') )
+    | Val (Num (I64 0L)), _ -> (
+      match op with
+      | Add | Or | Sub -> e2'
+      | And | DivS | DivU | Mul | RemS | RemU -> Val (Num (I64 0L))
+      | _ -> Binop (I64 op, e1', e2') )
+    | _, Val (Num (I64 0L)) -> (
+      match op with
+      | Add | Or | Sub -> e1'
+      | And | Mul -> Val (Num (I64 0L))
+      | _ -> Binop (I64 op, e1', e2') )
+    | Val (Num v1), Val (Num v2) ->
+      Val (Num (Eval_numeric.eval_binop (I64 op) v1 v2))
+    | Binop (I64 op2, x, Val (Num v1)), Val (Num v2) when not (is_num x) -> (
+      match (op, op2) with
+      | Add, Add ->
+        let v = Eval_numeric.eval_binop (I64 Add) v1 v2 in
+        Binop (I64 Add, x, Val (Num v))
+      | Add, Sub | Sub, Add ->
+        let v = Eval_numeric.eval_binop (I64 Sub) v1 v2 in
+        Binop (I64 Add, x, Val (Num v))
+      | Sub, Sub ->
+        let v = Eval_numeric.eval_binop (I64 Add) v1 v2 in
+        Binop (I64 Sub, x, Val (Num v))
+      | _, _ -> Binop (I64 op, e1', e2') )
+    | (bop, Val (Num (I64 1L)) | Val (Num (I64 1L)), bop)
+      when is_relop bop && Poly.(op = And) ->
+      bop
+    | _ -> Binop (I64 op, e1', e2') )
   | Relop (I32 op, e1, e2) -> (
-      let e1' = simplify e1
-      and e2' = simplify e2 in
-      match (e1', e2') with
-      | Val (Num v1), Val (Num v2) ->
-        let ret = Eval_numeric.eval_relop (I32 op) v1 v2 in
-        Val (Num (Num.num_of_bool ret))
-      | SymPtr (_, _), Val (Num (I32 0l)) | Val (Num (I32 0l)), SymPtr (_, _) -> (
-          match op with
-          | Eq -> Val (Num (I32 0l))
-          | Ne -> Val (Num (I32 1l))
-          | _ -> Relop (I32 op, e1', e2') )
-      | SymPtr (b1, os1), SymPtr (b2, os2) -> (
-          let open Int32 in
-          match op with
-          | Eq when b1 = b2 -> Relop (I32 Eq, os1, os2)
-          | Eq when b1 <> b2 -> Val (Num (I32 0l))
-          | Ne when b1 = b2 -> Relop (I32 Ne, os1, os2)
-          | Ne when b1 <> b2 -> Val (Num (I32 1l))
-          | LtU when b1 = b2 -> Relop (I32 LtU, os1, os2)
-          | LeU when b1 = b2 -> Relop (I32 LeU, os1, os2)
-          | LtU -> Relop (I32 LtU, Val (Num (I32 b1)), Val (Num (I32 b2)))
-          | LeU -> Relop (I32 LeU, Val (Num (I32 b1)), Val (Num (I32 b2)))
-          | GtU when b1 = b2 -> Relop (I32 GtU, os1, os2)
-          | GeU when b1 = b2 -> Relop (I32 GeU, os1, os2)
-          | GtU -> Relop (I32 GtU, Val (Num (I32 b1)), Val (Num (I32 b2)))
-          | GeU -> Relop (I32 GeU, Val (Num (I32 b1)), Val (Num (I32 b2)))
-          | _ -> Relop (I32 op, e1', e2') )
+    let e1' = simplify e1
+    and e2' = simplify e2 in
+    match (e1', e2') with
+    | Val (Num v1), Val (Num v2) ->
+      let ret = Eval_numeric.eval_relop (I32 op) v1 v2 in
+      Val (Num (Num.num_of_bool ret))
+    | SymPtr (_, _), Val (Num (I32 0l)) | Val (Num (I32 0l)), SymPtr (_, _) -> (
+      match op with
+      | Eq -> Val (Num (I32 0l))
+      | Ne -> Val (Num (I32 1l))
       | _ -> Relop (I32 op, e1', e2') )
+    | SymPtr (b1, os1), SymPtr (b2, os2) -> (
+      let open Int32 in
+      match op with
+      | Eq when b1 = b2 -> Relop (I32 Eq, os1, os2)
+      | Eq when b1 <> b2 -> Val (Num (I32 0l))
+      | Ne when b1 = b2 -> Relop (I32 Ne, os1, os2)
+      | Ne when b1 <> b2 -> Val (Num (I32 1l))
+      | LtU when b1 = b2 -> Relop (I32 LtU, os1, os2)
+      | LeU when b1 = b2 -> Relop (I32 LeU, os1, os2)
+      | LtU -> Relop (I32 LtU, Val (Num (I32 b1)), Val (Num (I32 b2)))
+      | LeU -> Relop (I32 LeU, Val (Num (I32 b1)), Val (Num (I32 b2)))
+      | GtU when b1 = b2 -> Relop (I32 GtU, os1, os2)
+      | GeU when b1 = b2 -> Relop (I32 GeU, os1, os2)
+      | GtU -> Relop (I32 GtU, Val (Num (I32 b1)), Val (Num (I32 b2)))
+      | GeU -> Relop (I32 GeU, Val (Num (I32 b1)), Val (Num (I32 b2)))
+      | _ -> Relop (I32 op, e1', e2') )
+    | _ -> Relop (I32 op, e1', e2') )
   | Extract (_, _, _) when not extract -> e
   | Extract (s, h, l) when extract -> (
-      match s with
-      | Val (Num (I64 x)) ->
-        let x' = nland64 (Int64.shift_right x (l * 8)) (h - l) in
-        Val (Num (I64 x'))
-      | _ when h - l = size (type_of s) -> s
-      | _ -> e )
+    match s with
+    | Val (Num (I64 x)) ->
+      let x' = nland64 (Int64.shift_right x (l * 8)) (h - l) in
+      Val (Num (I64 x'))
+    | _ when h - l = size (type_of s) -> s
+    | _ -> e )
   | Concat (e1, e2) -> (
-      let e1' = simplify ~extract:false e1
-      and e2' = simplify ~extract:false e2 in
-      match (e1', e2') with
-      | Extract (Val (Num (I64 x2)), h2, l2), Extract (Val (Num (I64 x1)), h1, l1)
-        ->
-        let d1 = h1 - l1
-        and d2 = h2 - l2 in
-        let x1' = nland64 (Int64.shift_right x1 (l1 * 8)) d1
-        and x2' = nland64 (Int64.shift_right x2 (l2 * 8)) d2 in
-        let x = Int64.(shift_left x2' (Int.( * ) d1 8) lor x1') in
-        Extract (Val (Num (I64 x)), d1 + d2, 0)
-      | Extract (Val (Num (I32 x2)), h2, l2), Extract (Val (Num (I32 x1)), h1, l1)
-        ->
-        let d1 = h1 - l1
-        and d2 = h2 - l2 in
-        let x1' = nland32 (Int32.shift_right x1 (l1 * 8)) d1
-        and x2' = nland32 (Int32.shift_right x2 (l2 * 8)) d2 in
-        let x = Int32.(shift_left x2' (Int.( * ) d1 8) lor x1') in
-        Extract (Val (Num (I32 x)), d1 + d2, 0)
-      | Extract (s1, h, m1), Extract (s2, m2, l) when Poly.(s1 = s2) && m1 = m2 ->
-        Extract (s1, h, l)
-      | ( Extract (Val (Num (I64 x2)), h2, l2)
-        , Concat (Extract (Val (Num (I64 x1)), h1, l1), se) )
-        when not (is_num se) ->
-        let d1 = h1 - l1
-        and d2 = h2 - l2 in
-        let x1' = nland64 (Int64.shift_right x1 (l1 * 8)) d1
-        and x2' = nland64 (Int64.shift_right x2 (l2 * 8)) d2 in
-        let x = Int64.(shift_left x2' (Int.( * ) d1 8) lor x1') in
-        Extract (Val (Num (I64 x)), d1 + d2, 0) ++ se
-      | _ -> e1' ++ e2' )
+    let e1' = simplify ~extract:false e1
+    and e2' = simplify ~extract:false e2 in
+    match (e1', e2') with
+    | Extract (Val (Num (I64 x2)), h2, l2), Extract (Val (Num (I64 x1)), h1, l1)
+      ->
+      let d1 = h1 - l1
+      and d2 = h2 - l2 in
+      let x1' = nland64 (Int64.shift_right x1 (l1 * 8)) d1
+      and x2' = nland64 (Int64.shift_right x2 (l2 * 8)) d2 in
+      let x = Int64.(shift_left x2' (Int.( * ) d1 8) lor x1') in
+      Extract (Val (Num (I64 x)), d1 + d2, 0)
+    | Extract (Val (Num (I32 x2)), h2, l2), Extract (Val (Num (I32 x1)), h1, l1)
+      ->
+      let d1 = h1 - l1
+      and d2 = h2 - l2 in
+      let x1' = nland32 (Int32.shift_right x1 (l1 * 8)) d1
+      and x2' = nland32 (Int32.shift_right x2 (l2 * 8)) d2 in
+      let x = Int32.(shift_left x2' (Int.( * ) d1 8) lor x1') in
+      Extract (Val (Num (I32 x)), d1 + d2, 0)
+    | Extract (s1, h, m1), Extract (s2, m2, l) when Poly.(s1 = s2) && m1 = m2 ->
+      Extract (s1, h, l)
+    | ( Extract (Val (Num (I64 x2)), h2, l2)
+      , Concat (Extract (Val (Num (I64 x1)), h1, l1), se) )
+      when not (is_num se) ->
+      let d1 = h1 - l1
+      and d2 = h2 - l2 in
+      let x1' = nland64 (Int64.shift_right x1 (l1 * 8)) d1
+      and x2' = nland64 (Int64.shift_right x2 (l2 * 8)) d2 in
+      let x = Int64.(shift_left x2' (Int.( * ) d1 8) lor x1') in
+      Extract (Val (Num (I64 x)), d1 + d2, 0) ++ se
+    | _ -> e1' ++ e2' )
   | _ -> e
 
 let mk_relop ?(reduce : bool = true) (e : expr) (t : num_type) : expr =

--- a/lib/expression.ml
+++ b/lib/expression.ml
@@ -181,95 +181,110 @@ let rec type_of (e : expr) : expr_type =
 let negate_relop (e : expr) : expr =
   match e with
   | Relop (op, e1, e2) -> (
-    match op with
-    | Int op' -> Relop (Int (I.neg_relop op'), e1, e2)
-    | Real op' -> Relop (Real (R.neg_relop op'), e1, e2)
-    | Bool op' -> Relop (Bool (B.neg_relop op'), e1, e2)
-    | Str op' -> Relop (Str (S.neg_relop op'), e1, e2)
-    | I32 op' -> Relop (I32 (I32.neg_relop op'), e1, e2)
-    | I64 op' -> Relop (I64 (I64.neg_relop op'), e1, e2)
-    | F32 op' -> Relop (F32 (F32.neg_relop op'), e1, e2)
-    | F64 op' -> Relop (F64 (F64.neg_relop op'), e1, e2) )
+      match op with
+      | Int op' -> Relop (Int (I.neg_relop op'), e1, e2)
+      | Real op' -> Relop (Real (R.neg_relop op'), e1, e2)
+      | Bool op' -> Relop (Bool (B.neg_relop op'), e1, e2)
+      | Str op' -> Relop (Str (S.neg_relop op'), e1, e2)
+      | I32 op' -> Relop (I32 (I32.neg_relop op'), e1, e2)
+      | I64 op' -> Relop (I64 (I64.neg_relop op'), e1, e2)
+      | F32 op' -> Relop (F32 (F32.neg_relop op'), e1, e2)
+      | F64 op' -> Relop (F64 (F64.neg_relop op'), e1, e2) )
   | _ -> raise InvalidRelop
 
-let rec to_string (e : expr) : String.t =
+let pp_unop fmt =
+  let fprintf = Format.fprintf in
+  function
+  | Int op -> fprintf fmt "int.%s" @@ I.string_of_unop op
+  | Real op -> fprintf fmt "real.%s" @@ R.string_of_unop op
+  | Bool op -> fprintf fmt "bool.%s" @@ B.string_of_unop op
+  | Str op -> fprintf fmt "str.%s" @@ S.string_of_unop op
+  | I32 op -> fprintf fmt "i32.%s" @@ I32.string_of_unop op
+  | I64 op -> fprintf fmt "i64.%s" @@ I64.string_of_unop op
+  | F32 op -> fprintf fmt "f32.%s" @@ F32.string_of_unop op
+  | F64 op -> fprintf fmt "f64.%s" @@ F64.string_of_unop op
+
+let pp_binop fmt =
+  let fprintf = Format.fprintf in
+  function
+  | Int op -> fprintf fmt "int.%s" @@ I.string_of_binop op
+  | Real op -> fprintf fmt "real.%s" @@ R.string_of_binop op
+  | Bool op -> fprintf fmt "bool.%s" @@ B.string_of_binop op
+  | Str op -> fprintf fmt "str.%s" @@ S.string_of_binop op
+  | I32 op -> fprintf fmt "i32.%s" @@ I32.string_of_binop op
+  | I64 op -> fprintf fmt "i64.%s" @@ I64.string_of_binop op
+  | F32 op -> fprintf fmt "f32.%s" @@ F32.string_of_binop op
+  | F64 op -> fprintf fmt "f64.%s" @@ F64.string_of_binop op
+
+let pp_triop fmt =
+  let fprintf = Format.fprintf in
+  function
+  | Int op -> fprintf fmt "int.%s" @@ I.string_of_triop op
+  | Real op -> fprintf fmt "real.%s" @@ R.string_of_triop op
+  | Bool op -> fprintf fmt "bool.%s" @@ B.string_of_triop op
+  | Str op -> fprintf fmt "str.%s" @@ S.string_of_triop op
+  | I32 op -> fprintf fmt "i32.%s" @@ I32.string_of_triop op
+  | I64 op -> fprintf fmt "i64.%s" @@ I64.string_of_triop op
+  | F32 op -> fprintf fmt "f32.%s" @@ F32.string_of_triop op
+  | F64 op -> fprintf fmt "f64.%s" @@ F64.string_of_triop op
+
+let pp_relop fmt =
+  let fprintf = Format.fprintf in
+  function
+  | Int op -> fprintf fmt "int.%s" @@ I.string_of_relop op
+  | Real op -> fprintf fmt "real.%s" @@ R.string_of_relop op
+  | Bool op -> fprintf fmt "bool.%s" @@ B.string_of_relop op
+  | Str op -> fprintf fmt "str.%s" @@ S.string_of_relop op
+  | I32 op -> fprintf fmt "i32.%s" @@ I32.string_of_relop op
+  | I64 op -> fprintf fmt "i64.%s" @@ I64.string_of_relop op
+  | F32 op -> fprintf fmt "f32.%s" @@ F32.string_of_relop op
+  | F64 op -> fprintf fmt "f64.%s" @@ F64.string_of_relop op
+
+let pp_cvtop fmt =
+  let fprintf = Format.fprintf in
+  function
+  | Int op -> fprintf fmt "int.%s" @@ I.string_of_cvtop op
+  | Real op -> fprintf fmt "real.%s" @@ R.string_of_cvtop op
+  | Bool op -> fprintf fmt "bool.%s" @@ B.string_of_cvtop op
+  | Str op -> fprintf fmt "str.%s" @@ S.string_of_cvtop op
+  | I32 op -> fprintf fmt "i32.%s" @@ I32.string_of_cvtop op
+  | I64 op -> fprintf fmt "i64.%s" @@ I64.string_of_cvtop op
+  | F32 op -> fprintf fmt "f32.%s" @@ F32.string_of_cvtop op
+  | F64 op -> fprintf fmt "f64.%s" @@ F64.string_of_cvtop op
+
+let pp_quantifier fmt = function
+  | Forall -> Format.pp_print_string fmt "forall"
+  | Exists -> Format.pp_print_string fmt "exists"
+
+let pp_vars fmt vars =
+  Format.pp_print_list
+    ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ", ")
+    Symbol.pp
+    fmt vars
+
+let rec pp fmt (e : expr) =
+  let fprintf = Format.fprintf in
   match e with
-  | Val v -> Value.to_string v
+  | Val v -> fprintf fmt "%a" Value.pp v
   | SymPtr (base, offset) ->
-    let str_o = to_string offset in
-    sprintf "(i32.add (i32 %ld) %s)" base str_o
+    fprintf fmt "(i32.add (i32 %ld) %a)" base pp offset
   | Unop (op, e) ->
-    let str_op =
-      match op with
-      | Int op -> "int." ^ I.string_of_unop op
-      | Real op -> "real." ^ R.string_of_unop op
-      | Bool op -> "bool." ^ B.string_of_unop op
-      | Str op -> "str." ^ S.string_of_unop op
-      | I32 op -> "i32." ^ I32.string_of_unop op
-      | I64 op -> "i64." ^ I64.string_of_unop op
-      | F32 op -> "f32." ^ F32.string_of_unop op
-      | F64 op -> "f64." ^ F64.string_of_unop op
-    in
-    sprintf "(%s %s)" str_op (to_string e)
+    fprintf fmt "(%a %a)" pp_unop op pp e
   | Binop (op, e1, e2) ->
-    let str_op =
-      match op with
-      | Int op -> "int." ^ I.string_of_binop op
-      | Real op -> "real." ^ R.string_of_binop op
-      | Bool op -> "bool." ^ B.string_of_binop op
-      | Str op -> "str." ^ S.string_of_binop op
-      | I32 op -> "i32." ^ I32.string_of_binop op
-      | I64 op -> "i64." ^ I64.string_of_binop op
-      | F32 op -> "f32." ^ F32.string_of_binop op
-      | F64 op -> "f64." ^ F64.string_of_binop op
-    in
-    sprintf "(%s %s %s)" str_op (to_string e1) (to_string e2)
+    fprintf fmt "(%a %a %a)" pp_binop op pp e1 pp e2
   | Triop (op, e1, e2, e3) ->
-    let str_op =
-      match op with
-      | Int op -> "int." ^ I.string_of_triop op
-      | Real op -> "real." ^ R.string_of_triop op
-      | Bool op -> "bool." ^ B.string_of_triop op
-      | Str op -> "str." ^ S.string_of_triop op
-      | I32 op -> "i32." ^ I32.string_of_triop op
-      | I64 op -> "i64." ^ I64.string_of_triop op
-      | F32 op -> "f32." ^ F32.string_of_triop op
-      | F64 op -> "f64." ^ F64.string_of_triop op
-    in
-    sprintf "(%s %s %s %s)" str_op (to_string e1) (to_string e2) (to_string e3)
+    fprintf fmt "(%a %a %a %a)" pp_triop op pp e1 pp e2 pp e3
   | Relop (op, e1, e2) ->
-    let str_op =
-      match op with
-      | Int op -> "int." ^ I.string_of_relop op
-      | Real op -> "real." ^ R.string_of_relop op
-      | Bool op -> "bool." ^ B.string_of_relop op
-      | Str op -> "str." ^ S.string_of_relop op
-      | I32 op -> "i32." ^ I32.string_of_relop op
-      | I64 op -> "i64." ^ I64.string_of_relop op
-      | F32 op -> "f32." ^ F32.string_of_relop op
-      | F64 op -> "f64." ^ F64.string_of_relop op
-    in
-    sprintf "(%s %s %s)" str_op (to_string e1) (to_string e2)
+    fprintf fmt "(%a %a %a)" pp_relop op pp e1 pp e2
   | Cvtop (op, e) ->
-    let str_op =
-      match op with
-      | Int op -> "int." ^ I.string_of_cvtop op
-      | Real op -> "real." ^ R.string_of_cvtop op
-      | Bool op -> "bool." ^ B.string_of_cvtop op
-      | Str op -> "str." ^ S.string_of_cvtop op
-      | I32 op -> "i32." ^ I32.string_of_cvtop op
-      | I64 op -> "i64." ^ I64.string_of_cvtop op
-      | F32 op -> "f32." ^ F32.string_of_cvtop op
-      | F64 op -> "f64." ^ F64.string_of_cvtop op
-    in
-    sprintf "(%s %s)" str_op (to_string e)
-  | Symbol s -> Symbol.to_string s
-  | Extract (e, h, l) -> sprintf "(extract %s %d %d)" (to_string e) l h
-  | Concat (e1, e2) -> sprintf "(++ %s %s)" (to_string e1) (to_string e2)
+    fprintf fmt "(%a %a)" pp_cvtop op pp e
+  | Symbol s -> fprintf fmt "%a" Symbol.pp s
+  | Extract (e, h, l) -> fprintf fmt "(extract %a %d %d)" pp e l h
+  | Concat (e1, e2) -> fprintf fmt "(++ %a %a)" pp e1 pp e2
   | Quantifier (qt, vars, body, _) ->
-    let qt' = match qt with Forall -> "forall" | Exists -> "exists" in
-    let xs' = String.concat ~sep:", " (List.map ~f:Symbol.to_string vars) in
-    sprintf "%s (%s) %s" qt' xs' (to_string body)
+    fprintf fmt "%a (%a) %a" pp_quantifier qt pp_vars vars pp body
+
+let to_string e = Format.asprintf "%a" pp e
 
 let to_smt (es : expr List.t) : String.t =
   let symbols =
@@ -353,176 +368,176 @@ let rec simplify ?(extract = true) (e : expr) : expr =
   | Val v -> Val v
   | SymPtr (base, offset) -> SymPtr (base, simplify offset)
   | Binop (I32 op, e1, e2) -> (
-    let e1' = simplify e1
-    and e2' = simplify e2 in
-    match (e1', e2') with
-    | SymPtr (b1, os1), SymPtr (b2, os2) -> (
-      match op with
-      | Sub when Int32.(b1 = b2) -> simplify (Binop (I32 Sub, os1, os2))
+      let e1' = simplify e1
+      and e2' = simplify e2 in
+      match (e1', e2') with
+      | SymPtr (b1, os1), SymPtr (b2, os2) -> (
+          match op with
+          | Sub when Int32.(b1 = b2) -> simplify (Binop (I32 Sub, os1, os2))
+          | _ -> Binop (I32 op, e1', e2') )
+      | SymPtr (base, offset), _ -> (
+          match op with
+          | Add ->
+            let new_offset = simplify (Binop (I32 Add, offset, e2')) in
+            simplify (SymPtr (base, new_offset))
+          | Sub ->
+            let new_offset = simplify (Binop (I32 Sub, offset, e2')) in
+            simplify (SymPtr (base, new_offset))
+          | _ -> Binop (I32 op, e1', e2') )
+      | _, SymPtr (base, offset) -> (
+          match op with
+          | Add ->
+            let new_offset = simplify (Binop (I32 Add, offset, e1')) in
+            simplify (SymPtr (base, new_offset))
+          | _ -> Binop (I32 op, e1', e2') )
+      | Val (Num (I32 0l)), _ -> (
+          match op with
+          | Add | Or | Sub -> e2'
+          | And | DivS | DivU | Mul | RemS | RemU -> Val (Num (I32 0l))
+          | _ -> Binop (I32 op, e1', e2') )
+      | _, Val (Num (I32 0l)) -> (
+          match op with
+          | Add | Or | Sub -> e1'
+          | And | Mul -> Val (Num (I32 0l))
+          | _ -> Binop (I32 op, e1', e2') )
+      | Val (Num n1), Val (Num n2) ->
+        Val (Num (Eval_numeric.eval_binop (I32 op) n1 n2))
+      | Binop (I32 op2, x, Val (Num v1)), Val (Num v2) when not (is_num x) -> (
+          match (op, op2) with
+          | Add, Add ->
+            let v = Eval_numeric.eval_binop (I32 Add) v1 v2 in
+            Binop (I32 Add, x, Val (Num v))
+          | Add, Sub | Sub, Add ->
+            let v = Eval_numeric.eval_binop (I32 Sub) v1 v2 in
+            Binop (I32 Add, x, Val (Num v))
+          | Sub, Sub ->
+            let v = Eval_numeric.eval_binop (I32 Add) v1 v2 in
+            Binop (I32 Sub, x, Val (Num v))
+          | _, _ -> Binop (I32 op, e1', e2') )
+      | (bop, Val (Num (I32 1l)) | Val (Num (I32 1l)), bop)
+        when is_relop bop && Poly.(op = And) ->
+        bop
       | _ -> Binop (I32 op, e1', e2') )
-    | SymPtr (base, offset), _ -> (
-      match op with
-      | Add ->
-        let new_offset = simplify (Binop (I32 Add, offset, e2')) in
-        simplify (SymPtr (base, new_offset))
-      | Sub ->
-        let new_offset = simplify (Binop (I32 Sub, offset, e2')) in
-        simplify (SymPtr (base, new_offset))
-      | _ -> Binop (I32 op, e1', e2') )
-    | _, SymPtr (base, offset) -> (
-      match op with
-      | Add ->
-        let new_offset = simplify (Binop (I32 Add, offset, e1')) in
-        simplify (SymPtr (base, new_offset))
-      | _ -> Binop (I32 op, e1', e2') )
-    | Val (Num (I32 0l)), _ -> (
-      match op with
-      | Add | Or | Sub -> e2'
-      | And | DivS | DivU | Mul | RemS | RemU -> Val (Num (I32 0l))
-      | _ -> Binop (I32 op, e1', e2') )
-    | _, Val (Num (I32 0l)) -> (
-      match op with
-      | Add | Or | Sub -> e1'
-      | And | Mul -> Val (Num (I32 0l))
-      | _ -> Binop (I32 op, e1', e2') )
-    | Val (Num n1), Val (Num n2) ->
-      Val (Num (Eval_numeric.eval_binop (I32 op) n1 n2))
-    | Binop (I32 op2, x, Val (Num v1)), Val (Num v2) when not (is_num x) -> (
-      match (op, op2) with
-      | Add, Add ->
-        let v = Eval_numeric.eval_binop (I32 Add) v1 v2 in
-        Binop (I32 Add, x, Val (Num v))
-      | Add, Sub | Sub, Add ->
-        let v = Eval_numeric.eval_binop (I32 Sub) v1 v2 in
-        Binop (I32 Add, x, Val (Num v))
-      | Sub, Sub ->
-        let v = Eval_numeric.eval_binop (I32 Add) v1 v2 in
-        Binop (I32 Sub, x, Val (Num v))
-      | _, _ -> Binop (I32 op, e1', e2') )
-    | (bop, Val (Num (I32 1l)) | Val (Num (I32 1l)), bop)
-      when is_relop bop && Poly.(op = And) ->
-      bop
-    | _ -> Binop (I32 op, e1', e2') )
   | Binop (I64 op, e1, e2) -> (
-    let e1' = simplify e1
-    and e2' = simplify e2 in
-    match (e1', e2') with
-    | SymPtr (b1, os1), SymPtr (b2, os2) -> (
-      match op with
-      | Sub when Int32.(b1 = b2) -> simplify (Binop (I64 Sub, os1, os2))
+      let e1' = simplify e1
+      and e2' = simplify e2 in
+      match (e1', e2') with
+      | SymPtr (b1, os1), SymPtr (b2, os2) -> (
+          match op with
+          | Sub when Int32.(b1 = b2) -> simplify (Binop (I64 Sub, os1, os2))
+          | _ -> Binop (I64 op, e1', e2') )
+      | SymPtr (base, offset), _ -> (
+          match op with
+          | Add ->
+            let new_offset = simplify (Binop (I64 Add, offset, e2')) in
+            simplify (SymPtr (base, new_offset))
+          | Sub ->
+            let new_offset = simplify (Binop (I64 Sub, offset, e2')) in
+            simplify (SymPtr (base, new_offset))
+          | _ -> Binop (I64 op, e1', e2') )
+      | _, SymPtr (base, offset) -> (
+          match op with
+          | Add ->
+            let new_offset = simplify (Binop (I64 Add, offset, e1')) in
+            simplify (SymPtr (base, new_offset))
+          | _ -> Binop (I64 op, e1', e2') )
+      | Val (Num (I64 0L)), _ -> (
+          match op with
+          | Add | Or | Sub -> e2'
+          | And | DivS | DivU | Mul | RemS | RemU -> Val (Num (I64 0L))
+          | _ -> Binop (I64 op, e1', e2') )
+      | _, Val (Num (I64 0L)) -> (
+          match op with
+          | Add | Or | Sub -> e1'
+          | And | Mul -> Val (Num (I64 0L))
+          | _ -> Binop (I64 op, e1', e2') )
+      | Val (Num v1), Val (Num v2) ->
+        Val (Num (Eval_numeric.eval_binop (I64 op) v1 v2))
+      | Binop (I64 op2, x, Val (Num v1)), Val (Num v2) when not (is_num x) -> (
+          match (op, op2) with
+          | Add, Add ->
+            let v = Eval_numeric.eval_binop (I64 Add) v1 v2 in
+            Binop (I64 Add, x, Val (Num v))
+          | Add, Sub | Sub, Add ->
+            let v = Eval_numeric.eval_binop (I64 Sub) v1 v2 in
+            Binop (I64 Add, x, Val (Num v))
+          | Sub, Sub ->
+            let v = Eval_numeric.eval_binop (I64 Add) v1 v2 in
+            Binop (I64 Sub, x, Val (Num v))
+          | _, _ -> Binop (I64 op, e1', e2') )
+      | (bop, Val (Num (I64 1L)) | Val (Num (I64 1L)), bop)
+        when is_relop bop && Poly.(op = And) ->
+        bop
       | _ -> Binop (I64 op, e1', e2') )
-    | SymPtr (base, offset), _ -> (
-      match op with
-      | Add ->
-        let new_offset = simplify (Binop (I64 Add, offset, e2')) in
-        simplify (SymPtr (base, new_offset))
-      | Sub ->
-        let new_offset = simplify (Binop (I64 Sub, offset, e2')) in
-        simplify (SymPtr (base, new_offset))
-      | _ -> Binop (I64 op, e1', e2') )
-    | _, SymPtr (base, offset) -> (
-      match op with
-      | Add ->
-        let new_offset = simplify (Binop (I64 Add, offset, e1')) in
-        simplify (SymPtr (base, new_offset))
-      | _ -> Binop (I64 op, e1', e2') )
-    | Val (Num (I64 0L)), _ -> (
-      match op with
-      | Add | Or | Sub -> e2'
-      | And | DivS | DivU | Mul | RemS | RemU -> Val (Num (I64 0L))
-      | _ -> Binop (I64 op, e1', e2') )
-    | _, Val (Num (I64 0L)) -> (
-      match op with
-      | Add | Or | Sub -> e1'
-      | And | Mul -> Val (Num (I64 0L))
-      | _ -> Binop (I64 op, e1', e2') )
-    | Val (Num v1), Val (Num v2) ->
-      Val (Num (Eval_numeric.eval_binop (I64 op) v1 v2))
-    | Binop (I64 op2, x, Val (Num v1)), Val (Num v2) when not (is_num x) -> (
-      match (op, op2) with
-      | Add, Add ->
-        let v = Eval_numeric.eval_binop (I64 Add) v1 v2 in
-        Binop (I64 Add, x, Val (Num v))
-      | Add, Sub | Sub, Add ->
-        let v = Eval_numeric.eval_binop (I64 Sub) v1 v2 in
-        Binop (I64 Add, x, Val (Num v))
-      | Sub, Sub ->
-        let v = Eval_numeric.eval_binop (I64 Add) v1 v2 in
-        Binop (I64 Sub, x, Val (Num v))
-      | _, _ -> Binop (I64 op, e1', e2') )
-    | (bop, Val (Num (I64 1L)) | Val (Num (I64 1L)), bop)
-      when is_relop bop && Poly.(op = And) ->
-      bop
-    | _ -> Binop (I64 op, e1', e2') )
   | Relop (I32 op, e1, e2) -> (
-    let e1' = simplify e1
-    and e2' = simplify e2 in
-    match (e1', e2') with
-    | Val (Num v1), Val (Num v2) ->
-      let ret = Eval_numeric.eval_relop (I32 op) v1 v2 in
-      Val (Num (Num.num_of_bool ret))
-    | SymPtr (_, _), Val (Num (I32 0l)) | Val (Num (I32 0l)), SymPtr (_, _) -> (
-      match op with
-      | Eq -> Val (Num (I32 0l))
-      | Ne -> Val (Num (I32 1l))
+      let e1' = simplify e1
+      and e2' = simplify e2 in
+      match (e1', e2') with
+      | Val (Num v1), Val (Num v2) ->
+        let ret = Eval_numeric.eval_relop (I32 op) v1 v2 in
+        Val (Num (Num.num_of_bool ret))
+      | SymPtr (_, _), Val (Num (I32 0l)) | Val (Num (I32 0l)), SymPtr (_, _) -> (
+          match op with
+          | Eq -> Val (Num (I32 0l))
+          | Ne -> Val (Num (I32 1l))
+          | _ -> Relop (I32 op, e1', e2') )
+      | SymPtr (b1, os1), SymPtr (b2, os2) -> (
+          let open Int32 in
+          match op with
+          | Eq when b1 = b2 -> Relop (I32 Eq, os1, os2)
+          | Eq when b1 <> b2 -> Val (Num (I32 0l))
+          | Ne when b1 = b2 -> Relop (I32 Ne, os1, os2)
+          | Ne when b1 <> b2 -> Val (Num (I32 1l))
+          | LtU when b1 = b2 -> Relop (I32 LtU, os1, os2)
+          | LeU when b1 = b2 -> Relop (I32 LeU, os1, os2)
+          | LtU -> Relop (I32 LtU, Val (Num (I32 b1)), Val (Num (I32 b2)))
+          | LeU -> Relop (I32 LeU, Val (Num (I32 b1)), Val (Num (I32 b2)))
+          | GtU when b1 = b2 -> Relop (I32 GtU, os1, os2)
+          | GeU when b1 = b2 -> Relop (I32 GeU, os1, os2)
+          | GtU -> Relop (I32 GtU, Val (Num (I32 b1)), Val (Num (I32 b2)))
+          | GeU -> Relop (I32 GeU, Val (Num (I32 b1)), Val (Num (I32 b2)))
+          | _ -> Relop (I32 op, e1', e2') )
       | _ -> Relop (I32 op, e1', e2') )
-    | SymPtr (b1, os1), SymPtr (b2, os2) -> (
-      let open Int32 in
-      match op with
-      | Eq when b1 = b2 -> Relop (I32 Eq, os1, os2)
-      | Eq when b1 <> b2 -> Val (Num (I32 0l))
-      | Ne when b1 = b2 -> Relop (I32 Ne, os1, os2)
-      | Ne when b1 <> b2 -> Val (Num (I32 1l))
-      | LtU when b1 = b2 -> Relop (I32 LtU, os1, os2)
-      | LeU when b1 = b2 -> Relop (I32 LeU, os1, os2)
-      | LtU -> Relop (I32 LtU, Val (Num (I32 b1)), Val (Num (I32 b2)))
-      | LeU -> Relop (I32 LeU, Val (Num (I32 b1)), Val (Num (I32 b2)))
-      | GtU when b1 = b2 -> Relop (I32 GtU, os1, os2)
-      | GeU when b1 = b2 -> Relop (I32 GeU, os1, os2)
-      | GtU -> Relop (I32 GtU, Val (Num (I32 b1)), Val (Num (I32 b2)))
-      | GeU -> Relop (I32 GeU, Val (Num (I32 b1)), Val (Num (I32 b2)))
-      | _ -> Relop (I32 op, e1', e2') )
-    | _ -> Relop (I32 op, e1', e2') )
   | Extract (_, _, _) when not extract -> e
   | Extract (s, h, l) when extract -> (
-    match s with
-    | Val (Num (I64 x)) ->
-      let x' = nland64 (Int64.shift_right x (l * 8)) (h - l) in
-      Val (Num (I64 x'))
-    | _ when h - l = size (type_of s) -> s
-    | _ -> e )
+      match s with
+      | Val (Num (I64 x)) ->
+        let x' = nland64 (Int64.shift_right x (l * 8)) (h - l) in
+        Val (Num (I64 x'))
+      | _ when h - l = size (type_of s) -> s
+      | _ -> e )
   | Concat (e1, e2) -> (
-    let e1' = simplify ~extract:false e1
-    and e2' = simplify ~extract:false e2 in
-    match (e1', e2') with
-    | Extract (Val (Num (I64 x2)), h2, l2), Extract (Val (Num (I64 x1)), h1, l1)
-      ->
-      let d1 = h1 - l1
-      and d2 = h2 - l2 in
-      let x1' = nland64 (Int64.shift_right x1 (l1 * 8)) d1
-      and x2' = nland64 (Int64.shift_right x2 (l2 * 8)) d2 in
-      let x = Int64.(shift_left x2' (Int.( * ) d1 8) lor x1') in
-      Extract (Val (Num (I64 x)), d1 + d2, 0)
-    | Extract (Val (Num (I32 x2)), h2, l2), Extract (Val (Num (I32 x1)), h1, l1)
-      ->
-      let d1 = h1 - l1
-      and d2 = h2 - l2 in
-      let x1' = nland32 (Int32.shift_right x1 (l1 * 8)) d1
-      and x2' = nland32 (Int32.shift_right x2 (l2 * 8)) d2 in
-      let x = Int32.(shift_left x2' (Int.( * ) d1 8) lor x1') in
-      Extract (Val (Num (I32 x)), d1 + d2, 0)
-    | Extract (s1, h, m1), Extract (s2, m2, l) when Poly.(s1 = s2) && m1 = m2 ->
-      Extract (s1, h, l)
-    | ( Extract (Val (Num (I64 x2)), h2, l2)
-      , Concat (Extract (Val (Num (I64 x1)), h1, l1), se) )
-      when not (is_num se) ->
-      let d1 = h1 - l1
-      and d2 = h2 - l2 in
-      let x1' = nland64 (Int64.shift_right x1 (l1 * 8)) d1
-      and x2' = nland64 (Int64.shift_right x2 (l2 * 8)) d2 in
-      let x = Int64.(shift_left x2' (Int.( * ) d1 8) lor x1') in
-      Extract (Val (Num (I64 x)), d1 + d2, 0) ++ se
-    | _ -> e1' ++ e2' )
+      let e1' = simplify ~extract:false e1
+      and e2' = simplify ~extract:false e2 in
+      match (e1', e2') with
+      | Extract (Val (Num (I64 x2)), h2, l2), Extract (Val (Num (I64 x1)), h1, l1)
+        ->
+        let d1 = h1 - l1
+        and d2 = h2 - l2 in
+        let x1' = nland64 (Int64.shift_right x1 (l1 * 8)) d1
+        and x2' = nland64 (Int64.shift_right x2 (l2 * 8)) d2 in
+        let x = Int64.(shift_left x2' (Int.( * ) d1 8) lor x1') in
+        Extract (Val (Num (I64 x)), d1 + d2, 0)
+      | Extract (Val (Num (I32 x2)), h2, l2), Extract (Val (Num (I32 x1)), h1, l1)
+        ->
+        let d1 = h1 - l1
+        and d2 = h2 - l2 in
+        let x1' = nland32 (Int32.shift_right x1 (l1 * 8)) d1
+        and x2' = nland32 (Int32.shift_right x2 (l2 * 8)) d2 in
+        let x = Int32.(shift_left x2' (Int.( * ) d1 8) lor x1') in
+        Extract (Val (Num (I32 x)), d1 + d2, 0)
+      | Extract (s1, h, m1), Extract (s2, m2, l) when Poly.(s1 = s2) && m1 = m2 ->
+        Extract (s1, h, l)
+      | ( Extract (Val (Num (I64 x2)), h2, l2)
+        , Concat (Extract (Val (Num (I64 x1)), h1, l1), se) )
+        when not (is_num se) ->
+        let d1 = h1 - l1
+        and d2 = h2 - l2 in
+        let x1' = nland64 (Int64.shift_right x1 (l1 * 8)) d1
+        and x2' = nland64 (Int64.shift_right x2 (l2 * 8)) d2 in
+        let x = Int64.(shift_left x2' (Int.( * ) d1 8) lor x1') in
+        Extract (Val (Num (I64 x)), d1 + d2, 0) ++ se
+      | _ -> e1' ++ e2' )
   | _ -> e
 
 let mk_relop ?(reduce : bool = true) (e : expr) (t : num_type) : expr =

--- a/lib/symbol.ml
+++ b/lib/symbol.ml
@@ -14,6 +14,5 @@ let equal (s1 : t) (s2 : t) : bool =
 
 let rename (s : t) (name : String.t) = { s with name }
 let type_of (s : t) : expr_type = s.sort
-
 let pp fmt s = Format.pp_print_string fmt s.name
 let to_string (s : t) : string = s.name

--- a/lib/symbol.ml
+++ b/lib/symbol.ml
@@ -14,4 +14,6 @@ let equal (s1 : t) (s2 : t) : bool =
 
 let rename (s : t) (name : String.t) = { s with name }
 let type_of (s : t) : expr_type = s.sort
+
+let pp fmt s = Format.pp_print_string fmt s.name
 let to_string (s : t) : string = s.name

--- a/lib/symbol.mli
+++ b/lib/symbol.mli
@@ -8,3 +8,4 @@ val equal : t -> t -> Bool.t
 val rename : t -> String.t -> t
 val type_of : t -> expr_type
 val to_string : t -> String.t
+val pp : Format.formatter -> t -> unit

--- a/lib/value.ml
+++ b/lib/value.ml
@@ -26,10 +26,12 @@ let type_of (v : t) : expr_type =
   | Num n -> Num.type_of n
   | Str _ -> `StrType
 
-let to_string (v : t) : String.t =
+let pp fmt (v : t) =
   match v with
-  | Int x -> Int.to_string x
-  | Real x -> Float.to_string x
-  | Bool x -> Bool.to_string x
-  | Num x -> Num.to_string x
-  | Str x -> "\"" ^ x ^ "\""
+  | Int x -> Format.pp_print_string fmt @@ Int.to_string x
+  | Real x -> Format.pp_print_string fmt @@ Float.to_string x
+  | Bool x -> Format.pp_print_string fmt @@ Bool.to_string x
+  | Num x -> Format.pp_print_string fmt @@ Num.to_string x
+  | Str x -> Format.fprintf fmt {|"%s"|} x
+
+let to_string v = Format.asprintf "%a" pp v

--- a/test/test_eval_numeric.ml
+++ b/test/test_eval_numeric.ml
@@ -1,7 +1,6 @@
 open Encoding
 
 let cvtop = Eval_numeric.eval_cvtop
-
 let%test _ = cvtop (I32 TruncSF32) (F32 (Int32.bits_of_float 8.5)) = I32 8l
 let%test _ = cvtop (I32 TruncSF64) (F64 (Int64.bits_of_float 8.5)) = I32 8l
 let%test _ = cvtop (I64 TruncSF32) (F32 (Int32.bits_of_float 8.5)) = I64 8L


### PR DESCRIPTION
Hi,

I rewrote `Expression.to_string` intro a `Expression.pp` function. This is using a buffered formatter and should avoid many useless allocations. The `to_string` is now simply a call to the new `pp` function.

I wrote a few more `pp` functions (in `Value` and `Symbol`) but there's still some left to do. :-)